### PR TITLE
ZipWriter support, RESPONSEFORMAT job param to select pkg type: CADC-10473

### DIFF
--- a/cadc-pkg-server/build.gradle
+++ b/cadc-pkg-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.0.0'
+version = '1.1.0'
 
 description = 'OpenCADC CADC package server library'
 def git_url = 'https://github.com/opencadc/dal'

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ArchiveWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ArchiveWriter.java
@@ -86,14 +86,14 @@ import org.apache.log4j.Logger;
 public abstract class ArchiveWriter {
     private static final Logger log = Logger.getLogger(ArchiveWriter.class);
 
-    ArchiveOutputStream tout;
+    ArchiveOutputStream aout;
 
     public ArchiveWriter(OutputStream ostream) {
     }
 
     public void close() throws IOException {
-        tout.finish();
-        tout.close();
+        aout.finish();
+        aout.close();
     }
 
     /**
@@ -106,7 +106,7 @@ public abstract class ArchiveWriter {
         boolean openEntry = false;
 
         try {
-            //TODO GETs will probably not work with vault
+            // TODO these GETs will not work for directories or empty files in vault
             // HEAD to get entry metadata
             URL packageURL = packageItem.getURL();
             HttpGet get = new HttpGet(packageURL, true);
@@ -128,7 +128,7 @@ public abstract class ArchiveWriter {
             // the input stream needs to be written to the output stream that tout holds.
             // but the Apache Commons Compress library does whatever magic it does when the
             // file is written. And
-            tout.putArchiveEntry(e);
+            aout.putArchiveEntry(e);
 
             // headers for entry have been written, body has not,
             // so consider this entry 'open'
@@ -137,11 +137,11 @@ public abstract class ArchiveWriter {
             // Copy the get InputStream to the package OutputStream
             InputStream getIOStream = get.getInputStream();
             MultiBufferIO multiBufferIO = new MultiBufferIO();
-            multiBufferIO.copy(getIOStream, tout);
+            multiBufferIO.copy(getIOStream, aout);
 
         } finally {
             if (openEntry) {
-                tout.closeArchiveEntry();
+                aout.closeArchiveEntry();
             }
         }
     }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2022.                            (c) 2022.
+ *  (c) 2021.                            (c) 2021.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
@@ -83,17 +83,14 @@ import java.net.URL;
 public class PackageItem {
     private final URL url;
     private final String relativePath;
-    private final boolean isDirectory;
 
     /**
      * Instantiate a PackageItem object.
      * @param url - URL where a file can be accessed for download.
      * @param relativePath - Relative path of the file referenced by url parameter.
      *                     Used to build the correct directory structure in the final package.
-     * @param isDirectory - whether the item represents a directory
      */
-    public PackageItem(URL url, String relativePath, boolean isDirectory) {
-
+    public PackageItem(URL url, String relativePath) {
         if (url == null) {
             throw new IllegalArgumentException("parameter url required.");
         }
@@ -101,14 +98,11 @@ public class PackageItem {
         if (!StringUtil.hasText(relativePath)) {
             throw new IllegalArgumentException("parameter relativePath required.");
         }
-        this.isDirectory = isDirectory;
+
         this.url = url;
         this.relativePath = relativePath;
     }
 
-    public PackageItem(URL url, String relativePath) {
-        this(url, relativePath, false);
-    }
 
     public URL getURL() {
         return url;
@@ -117,9 +111,4 @@ public class PackageItem {
     public String getRelativePath() {
         return relativePath;
     }
-
-    public boolean isDirectory() {
-        return isDirectory;
-    }
-
 }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
@@ -106,7 +106,9 @@ public class PackageItem {
         this.relativePath = relativePath;
     }
 
-    public PackageItem(URL url, String relativePath) { this(url, relativePath, false); }
+    public PackageItem(URL url, String relativePath) {
+        this(url, relativePath, false);
+    }
 
     public URL getURL() {
         return url;

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageItem.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2021.                            (c) 2021.
+ *  (c) 2022.                            (c) 2022.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -83,14 +83,16 @@ import java.net.URL;
 public class PackageItem {
     private final URL url;
     private final String relativePath;
+    private final boolean isDirectory;
 
     /**
      * Instantiate a PackageItem object.
      * @param url - URL where a file can be accessed for download.
      * @param relativePath - Relative path of the file referenced by url parameter.
      *                     Used to build the correct directory structure in the final package.
+     * @param isDirectory - whether the item represents a directory
      */
-    public PackageItem(URL url, String relativePath) {
+    public PackageItem(URL url, String relativePath, boolean isDirectory) {
 
         if (url == null) {
             throw new IllegalArgumentException("parameter url required.");
@@ -99,10 +101,12 @@ public class PackageItem {
         if (!StringUtil.hasText(relativePath)) {
             throw new IllegalArgumentException("parameter relativePath required.");
         }
-
+        this.isDirectory = isDirectory;
         this.url = url;
         this.relativePath = relativePath;
     }
+
+    public PackageItem(URL url, String relativePath) { this(url, relativePath, false); }
 
     public URL getURL() {
         return url;
@@ -110,6 +114,10 @@ public class PackageItem {
 
     public String getRelativePath() {
         return relativePath;
+    }
+
+    public boolean isDirectory() {
+        return isDirectory;
     }
 
 }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
@@ -107,11 +107,19 @@ public abstract class PackageRunner implements JobRunner {
     protected Job job;
     protected String packageName;
 
-    // Default C-tor builds a Tar package
+    /**
+     * Default C-tor builds a Tar package
+     */
+
     public PackageRunner() {
         this(PackageRunner.TAR_TYPE);
     }
 
+    /**
+     * Ctor
+     * @param type Currently only "PackageRunner.TAR_TYPE" and "PackageRunner.ZIP_TYPE"
+     *             are supported
+     */
     public PackageRunner(String type) {
         if (PackageRunner.TAR_TYPE.equalsIgnoreCase(type) ||
                 PackageRunner.ZIP_TYPE.equalsIgnoreCase(type))

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
@@ -95,8 +95,8 @@ import org.apache.log4j.Logger;
  */
 public abstract class PackageRunner implements JobRunner {
     private static final Logger log = Logger.getLogger(PackageRunner.class);
-    public final static String TAR_TYPE = "application/x-tar";
-    public final static String ZIP_TYPE = "application/zip";
+    public static final String TAR_TYPE = "application/x-tar";
+    public static final String ZIP_TYPE = "application/zip";
 
     private JobUpdater jobUpdater;
     private SyncOutput syncOutput;
@@ -121,13 +121,10 @@ public abstract class PackageRunner implements JobRunner {
      *             are supported
      */
     public PackageRunner(String type) {
-        if (PackageRunner.TAR_TYPE.equalsIgnoreCase(type) ||
-                PackageRunner.ZIP_TYPE.equalsIgnoreCase(type))
-        {
+        if (PackageRunner.TAR_TYPE.equalsIgnoreCase(type)
+                || PackageRunner.ZIP_TYPE.equalsIgnoreCase(type)) {
             this.type = type;
-        }
-        else
-        {
+        } else {
             throw new IllegalArgumentException("Type " + type + " not supported.");
         }
     }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
@@ -101,7 +101,6 @@ public abstract class PackageRunner implements JobRunner {
     private SyncOutput syncOutput;
     private ByteCountOutputStream outputStreamCounter;
     private WebServiceLogInfo logInfo;
-    private String type;
 
     protected Job job;
     protected String packageName;
@@ -126,10 +125,6 @@ public abstract class PackageRunner implements JobRunner {
      * @return String with package name.
      */
     protected abstract String getPackageName();
-
-    public String getType() {
-        return this.type;
-    }
 
     @Override
     public void setJob(Job job) {
@@ -184,7 +179,6 @@ public abstract class PackageRunner implements JobRunner {
             // in the local Job instance
             Iterator<PackageItem> packageItems = getItems();
 
-            //
             if (StringUtil.hasText(packageName)) {
                 writer = initWriter(packageName);
             } else {
@@ -239,7 +233,7 @@ public abstract class PackageRunner implements JobRunner {
     }
 
     /**
-     * Set up PackageWriter.
+     * Set up PackageWriter and syncoutput for the requested RESPONSEFORMAT value.
      * Initialize syncOutput output stream with the correct content type and disposition
      * as provided by the writer class. Call writer ctor.
      * @param packageName

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageWriter.java
@@ -74,6 +74,7 @@ import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.ResourceAlreadyExistsException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.net.TransientException;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -149,7 +150,5 @@ public abstract class PackageWriter {
             }
         }
     }
-
-
 
 }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageWriter.java
@@ -88,8 +88,7 @@ public abstract class PackageWriter {
 
     ArchiveOutputStream aout;
 
-    public PackageWriter(OutputStream ostream) {
-    }
+    public PackageWriter(OutputStream ostream) { }
 
     /**
      * Implement this so the correct type of entry is created for writing.
@@ -121,22 +120,17 @@ public abstract class PackageWriter {
             // Iterator<PackageItem>
             URL packageURL = packageItem.getURL();
             HttpGet get = new HttpGet(packageURL, true);
-
-            // write() will throw all errors so they can be
-            // handled by messaging in the PackageRunner.doIt() class
             get.prepare();
 
             // get information common to all entries
             long contentLength = get.getContentLength();
             Date lastModified = get.getLastModified();
 
-            // create entry
+            // create entry (metadata) to be put to archive stream
             log.debug("next package entry: " + packageItem.getRelativePath() + "," + contentLength + "," + lastModified);
             ArchiveEntry e = createEntry(packageItem.getRelativePath(), contentLength, lastModified);
 
-            // the input stream needs to be written to the output stream that tout holds.
-            // but the Apache Commons Compress library does whatever magic it does when the
-            // file is written. And
+            // put archive entry to stream
             aout.putArchiveEntry(e);
 
             // headers for entry have been written, body has not,
@@ -144,6 +138,7 @@ public abstract class PackageWriter {
             openEntry = true;
 
             // Copy the get InputStream to the package OutputStream
+            // this is 'writing' the content of the file
             InputStream getIOStream = get.getInputStream();
             MultiBufferIO multiBufferIO = new MultiBufferIO();
             multiBufferIO.copy(getIOStream, aout);

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageWriter.java
@@ -89,7 +89,9 @@ public abstract class PackageWriter {
 
     ArchiveOutputStream aout;
 
-    public PackageWriter(OutputStream ostream) { }
+    public PackageWriter(ArchiveOutputStream archiveOutputStream) {
+        this.aout = archiveOutputStream;
+    }
 
     /**
      * Implement this so the correct type of entry is created for writing.
@@ -101,8 +103,10 @@ public abstract class PackageWriter {
     abstract ArchiveEntry createEntry(String name, long size, Date lastModifiedDate);
 
     public void close() throws IOException {
-        aout.finish();
-        aout.close();
+        if (aout != null) {
+            aout.finish();
+            aout.close();
+        }
     }
 
     /**
@@ -150,5 +154,4 @@ public abstract class PackageWriter {
             }
         }
     }
-
 }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
@@ -76,7 +76,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.log4j.Logger;
 
-public class TarWriter extends ArchiveWriter{
+public class TarWriter extends ArchiveWriter {
     private static final Logger log = Logger.getLogger(TarWriter.class);
 
     private OutputStream ostream;
@@ -97,7 +97,9 @@ public class TarWriter extends ArchiveWriter{
      * Wrapper for TarArchiveEntry class that enforces that every entry is not a directory
      */
     private class DynamicTarEntry extends TarArchiveEntry {
+
         private final boolean isDirectory;
+
         public DynamicTarEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
             super(name);
             this.isDirectory = isDirectory;

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
@@ -86,7 +86,7 @@ public class TarWriter extends ArchiveWriter{
         this.ostream = ostream;
         TarArchiveOutputStream taos = new TarArchiveOutputStream(ostream);
         taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-        this.tout = taos;
+        this.aout = taos;
     }
 
     ArchiveEntry createEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
@@ -84,8 +84,7 @@ public class TarWriter extends PackageWriter {
 
     public TarWriter(OutputStream ostream) {
         super(new TarArchiveOutputStream(ostream));
-        TarArchiveOutputStream tmp = (TarArchiveOutputStream)this.aout;
-        tmp.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+        ((TarArchiveOutputStream)super.aout).setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
     }
 
     ArchiveEntry createEntry(String name, long size, Date lastModifiedDate) {

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
@@ -82,20 +82,16 @@ public class TarWriter extends PackageWriter {
     public static final String MIME_TYPE = "application/x-tar";
     public static final String EXTENSION = ".tar";
 
-    private OutputStream ostream;
-
     public TarWriter(OutputStream ostream) {
-        super(ostream);
-        this.ostream = ostream;
-        TarArchiveOutputStream taos = new TarArchiveOutputStream(ostream);
-        taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-        this.aout = taos;
+        super(new TarArchiveOutputStream(ostream));
+        TarArchiveOutputStream tmp = (TarArchiveOutputStream)this.aout;
+        tmp.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
     }
 
     ArchiveEntry createEntry(String name, long size, Date lastModifiedDate) {
         return new DynamicTarEntry(name, size, lastModifiedDate);
     }
-    
+
     /**
      * Wrapper for TarArchiveEntry class.
      * isDirectory set to false - PackageWriter only writes files.

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
@@ -80,7 +80,7 @@ public class TarWriter extends PackageWriter {
     private static final Logger log = Logger.getLogger(TarWriter.class);
 
     public static final String MIME_TYPE = "application/x-tar";
-
+    public static final String EXTENSION = ".tar";
 
     private OutputStream ostream;
 

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
@@ -95,8 +95,7 @@ public class TarWriter extends PackageWriter {
     ArchiveEntry createEntry(String name, long size, Date lastModifiedDate) {
         return new DynamicTarEntry(name, size, lastModifiedDate);
     }
-
-
+    
     /**
      * Wrapper for TarArchiveEntry class.
      * isDirectory set to false - PackageWriter only writes files.

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/TarWriter.java
@@ -76,8 +76,11 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.log4j.Logger;
 
-public class TarWriter extends ArchiveWriter {
+public class TarWriter extends PackageWriter {
     private static final Logger log = Logger.getLogger(TarWriter.class);
+
+    public static final String MIME_TYPE = "application/x-tar";
+
 
     private OutputStream ostream;
 
@@ -89,20 +92,19 @@ public class TarWriter extends ArchiveWriter {
         this.aout = taos;
     }
 
-    ArchiveEntry createEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
-        return new DynamicTarEntry(name, size, lastModifiedDate, isDirectory);
+    ArchiveEntry createEntry(String name, long size, Date lastModifiedDate) {
+        return new DynamicTarEntry(name, size, lastModifiedDate);
     }
 
+
     /**
-     * Wrapper for TarArchiveEntry class that enforces that every entry is not a directory
+     * Wrapper for TarArchiveEntry class.
+     * isDirectory set to false - PackageWriter only writes files.
      */
     private class DynamicTarEntry extends TarArchiveEntry {
 
-        private final boolean isDirectory;
-
-        public DynamicTarEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
+        public DynamicTarEntry(String name, long size, Date lastModifiedDate) {
             super(name);
-            this.isDirectory = isDirectory;
             log.info("TAR ENTRY VALUES:" + name + size);
             if (lastModifiedDate != null) {
                 super.setModTime(lastModifiedDate);
@@ -112,7 +114,6 @@ public class TarWriter extends ArchiveWriter {
 
         @Override
         public boolean isDirectory() {
-            //TODO return this.isDirectory
             return false;
         }
     }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
@@ -69,6 +69,7 @@
 
 package org.opencadc.pkg.server;
 
+import ca.nrc.cadc.net.HttpGet;
 import java.io.OutputStream;
 import java.nio.file.attribute.FileTime;
 import java.util.Date;
@@ -77,8 +78,10 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.log4j.Logger;
 
-public class ZipWriter extends ArchiveWriter {
+public class ZipWriter extends PackageWriter {
     private static final Logger log = Logger.getLogger(ZipWriter.class);
+
+    public static final String MIME_TYPE = "application/zip";
 
     private OutputStream ostream;
 
@@ -88,19 +91,19 @@ public class ZipWriter extends ArchiveWriter {
         this.aout = new ZipArchiveOutputStream(ostream);;
     }
 
-    ArchiveEntry createEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
-        return new DynamicZipEntry(name, size, lastModifiedDate, isDirectory);
+    ArchiveEntry createEntry(String name, long size, Date lastModifiedDate) {
+        return new DynamicZipEntry(name, size, lastModifiedDate);
     }
 
     /**
-     * Wrapper for ZipArchiveEntry class that enforces that every entry is not a directory
+     * Wrapper for ZipArchiveEntry class.
+     * isDirectory set to false - PackageWriter only writes files.
      */
     private class DynamicZipEntry extends ZipArchiveEntry {
-        private final boolean isDirectory;
 
-        public DynamicZipEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
+        public DynamicZipEntry(String name, long size, Date lastModifiedDate) {
             super(name);
-            this.isDirectory = isDirectory;
+
             log.info("ZIP ENTRY VALUES:" + name + size);
             if (lastModifiedDate != null) {
                 super.setLastModifiedTime(FileTime.fromMillis(lastModifiedDate.getTime()));
@@ -110,7 +113,6 @@ public class ZipWriter extends ArchiveWriter {
 
         @Override
         public boolean isDirectory() {
-            //TODO return this.isDirectory
             return false;
         }
     }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
@@ -77,7 +77,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.log4j.Logger;
 
-public class ZipWriter extends ArchiveWriter{
+public class ZipWriter extends ArchiveWriter {
     private static final Logger log = Logger.getLogger(ZipWriter.class);
 
     private OutputStream ostream;

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
@@ -70,40 +70,41 @@
 package org.opencadc.pkg.server;
 
 import java.io.OutputStream;
+import java.nio.file.attribute.FileTime;
 import java.util.Date;
 import org.apache.commons.compress.archivers.ArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.log4j.Logger;
 
-public class TarWriter extends ArchiveWriter{
-    private static final Logger log = Logger.getLogger(TarWriter.class);
+public class ZipWriter extends ArchiveWriter{
+    private static final Logger log = Logger.getLogger(ZipWriter.class);
 
     private OutputStream ostream;
 
-    public TarWriter(OutputStream ostream) {
+    public ZipWriter(OutputStream ostream) {
         super(ostream);
         this.ostream = ostream;
-        TarArchiveOutputStream taos = new TarArchiveOutputStream(ostream);
-        taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-        this.tout = taos;
+        ZipArchiveOutputStream zaos = new ZipArchiveOutputStream(ostream);
+        this.tout = zaos;
     }
 
     ArchiveEntry createEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
-        return new DynamicTarEntry(name, size, lastModifiedDate, isDirectory);
+        return new DynamicZipEntry(name, size, lastModifiedDate, isDirectory);
     }
 
     /**
-     * Wrapper for TarArchiveEntry class that enforces that every entry is not a directory
+     * Wrapper for ZipArchiveEntry class that enforces that every entry is not a directory
      */
-    private class DynamicTarEntry extends TarArchiveEntry {
+    private class DynamicZipEntry extends ZipArchiveEntry {
         private final boolean isDirectory;
-        public DynamicTarEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
+
+        public DynamicZipEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
             super(name);
             this.isDirectory = isDirectory;
             log.info("TAR ENTRY VALUES:" + name + size);
             if (lastModifiedDate != null) {
-                super.setModTime(lastModifiedDate);
+                super.setLastModifiedTime(FileTime.fromMillis(lastModifiedDate.getTime()));
             }
             super.setSize(size);
         }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
@@ -82,6 +82,7 @@ public class ZipWriter extends PackageWriter {
     private static final Logger log = Logger.getLogger(ZipWriter.class);
 
     public static final String MIME_TYPE = "application/zip";
+    public static final String EXTENSION = ".zip";
 
     private OutputStream ostream;
 

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
@@ -85,8 +85,7 @@ public class ZipWriter extends ArchiveWriter{
     public ZipWriter(OutputStream ostream) {
         super(ostream);
         this.ostream = ostream;
-        ZipArchiveOutputStream zaos = new ZipArchiveOutputStream(ostream);
-        this.tout = zaos;
+        this.aout = new ZipArchiveOutputStream(ostream);;
     }
 
     ArchiveEntry createEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
@@ -102,7 +101,7 @@ public class ZipWriter extends ArchiveWriter{
         public DynamicZipEntry(String name, long size, Date lastModifiedDate, boolean isDirectory) {
             super(name);
             this.isDirectory = isDirectory;
-            log.info("TAR ENTRY VALUES:" + name + size);
+            log.info("ZIP ENTRY VALUES:" + name + size);
             if (lastModifiedDate != null) {
                 super.setLastModifiedTime(FileTime.fromMillis(lastModifiedDate.getTime()));
             }

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
@@ -84,12 +84,8 @@ public class ZipWriter extends PackageWriter {
     public static final String MIME_TYPE = "application/zip";
     public static final String EXTENSION = ".zip";
 
-    private OutputStream ostream;
-
     public ZipWriter(OutputStream ostream) {
-        super(ostream);
-        this.ostream = ostream;
-        this.aout = new ZipArchiveOutputStream(ostream);;
+        super(new ZipArchiveOutputStream(ostream));
     }
 
     ArchiveEntry createEntry(String name, long size, Date lastModifiedDate) {

--- a/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/TarWriterTest.java
+++ b/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/TarWriterTest.java
@@ -64,6 +64,7 @@
  *
  ************************************************************************
  */
+
 package org.opencadc.pkg.server;
 
 import ca.nrc.cadc.net.NetUtil;
@@ -92,18 +93,7 @@ public class TarWriterTest {
     static {
         Log4jInit.setLevel("ca.nrc.cadc.caom2.pkg", Level.INFO);
     }
-    
-    //@Test
-    public void testTemplate() {
-        try {
-            
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("Unexpected exception: " + unexpected);
-        }
-        
-    }
-    
+
     @Test
     public void testCreateTar() {
         try {
@@ -118,7 +108,7 @@ public class TarWriterTest {
             packageContents.add(pi2);
 
             File tmp = File.createTempFile("tartest", ".tar");
-            FileOutputStream fos=  new FileOutputStream(tmp);
+            FileOutputStream fos =  new FileOutputStream(tmp);
             TarWriter fw = new TarWriter(fos);
             for (PackageItem pi : packageContents) {
                 fw.write(pi);
@@ -145,8 +135,7 @@ public class TarWriterTest {
             Assert.assertEquals("name", "some/path/GovCanada.gif", c1.name);
             Assert.assertEquals("name", "another/path/SymbolCanada.gif", c2.name);
 
-        }
-        catch (Exception unexpected) {
+        } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);
             Assert.fail("Unexpected exception: " + unexpected);
         }

--- a/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/ZipWriterTest.java
+++ b/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/ZipWriterTest.java
@@ -1,0 +1,202 @@
+/*
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2022.                            (c) 2022.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************
+ */
+package org.opencadc.pkg.server;
+
+import ca.nrc.cadc.net.HttpGet;
+import ca.nrc.cadc.net.ResourceAlreadyExistsException;
+import ca.nrc.cadc.net.ResourceNotFoundException;
+import ca.nrc.cadc.net.TransientException;
+import ca.nrc.cadc.util.Log4jInit;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ZipWriterTest {
+    private static final Logger log = Logger.getLogger(ZipWriterTest.class);
+    
+    static {
+        Log4jInit.setLevel("ca.nrc.cadc.caom2.pkg", Level.INFO);
+    }
+    
+    //@Test
+    public void testTemplate() {
+        try {
+            
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("Unexpected exception: " + unexpected);
+        }
+        
+    }
+    
+    @Test
+    public void testCreateZip() {
+        try {
+            // Create PackageItems for testing
+            URL url1 = new URL("https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/GovCanada.gif");
+            PackageItem pi1 = new PackageItem(url1, "some/path/GovCanada.gif");
+            URL url2 = new URL("https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/SymbolCanada.gif");
+            PackageItem pi2 = new PackageItem(url2,"another/path/SymbolCanada.gif");
+            
+            List<PackageItem> packageContents = new ArrayList<PackageItem>();
+            packageContents.add(pi1);
+            packageContents.add(pi2);
+
+            File tmp = File.createTempFile("ziptest", ".zip");
+            FileOutputStream fos=  new FileOutputStream(tmp);
+            ArchiveWriter fw = new ZipWriter(fos);
+            for (PackageItem pi : packageContents) {
+                fw.write(pi);
+            }
+            fw.close();
+            
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ArchiveWriter bw = new ZipWriter(bos);
+            for (PackageItem pi : packageContents) {
+                bw.write(pi);
+            }
+            bw.close();
+
+            byte[] content = bos.toByteArray();
+            ByteArrayInputStream in = new ByteArrayInputStream(content);
+
+            ZipArchiveInputStream zip = new ZipArchiveInputStream(in);
+            Content c1 = getEntry(zip);
+            Content c2 = getEntry(zip);
+
+            ArchiveEntry te = zip.getNextZipEntry();
+            Assert.assertNull(te);
+
+            Assert.assertEquals("name", "some/path/GovCanada.gif", c1.name);
+            Assert.assertEquals("name", "another/path/SymbolCanada.gif", c2.name);
+
+            HttpGet get1 = new HttpGet(url1, true);
+            get1.prepare();
+            Assert.assertArrayEquals(c1.content, getUrlPayload(get1));
+
+            HttpGet get2 = new HttpGet(url2, true);
+            get2.prepare();
+            Assert.assertArrayEquals(c2.content, getUrlPayload(get2));
+
+        }
+        catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("Unexpected exception: " + unexpected);
+        }
+    }
+
+    class Content {
+        String name;
+        byte[] content;
+    }
+
+    private Content getEntry(ZipArchiveInputStream zip) throws IOException {
+        Content ret = new Content();
+        
+        ZipArchiveEntry entry = zip.getNextZipEntry();
+        ret.name = entry.getName();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        byte buffer[] = new byte[2048];
+        int read = 0;
+        while ((read = zip.read(buffer)) > 0) {
+            out.write(buffer, 0, read);
+        }
+        ret.content = out.toByteArray();
+        return ret;
+    }
+
+    private byte[] getUrlPayload(HttpGet get) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int nRead;
+        byte[] data = new byte[16384];
+
+        while ((nRead = get.getInputStream().read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, nRead);
+        }
+        return buffer.toByteArray();
+    }
+}

--- a/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/ZipWriterTest.java
+++ b/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/ZipWriterTest.java
@@ -68,9 +68,6 @@
 package org.opencadc.pkg.server;
 
 import ca.nrc.cadc.net.HttpGet;
-import ca.nrc.cadc.net.ResourceAlreadyExistsException;
-import ca.nrc.cadc.net.ResourceNotFoundException;
-import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.util.Log4jInit;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -84,9 +81,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.compress.archivers.ArchiveEntry;
-import org.apache.commons.compress.archivers.ArchiveInputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.log4j.Level;
@@ -116,14 +110,14 @@ public class ZipWriterTest {
 
             File tmp = File.createTempFile("ziptest", ".zip");
             FileOutputStream fos =  new FileOutputStream(tmp);
-            ArchiveWriter fw = new ZipWriter(fos);
+            PackageWriter fw = new ZipWriter(fos);
             for (PackageItem pi : packageContents) {
                 fw.write(pi);
             }
             fw.close();
             
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ArchiveWriter bw = new ZipWriter(bos);
+            PackageWriter bw = new ZipWriter(bos);
             for (PackageItem pi : packageContents) {
                 bw.write(pi);
             }

--- a/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/ZipWriterTest.java
+++ b/cadc-pkg-server/src/test/java/org/opencadc/pkg/server/ZipWriterTest.java
@@ -64,6 +64,7 @@
  *
  ************************************************************************
  */
+
 package org.opencadc.pkg.server;
 
 import ca.nrc.cadc.net.HttpGet;
@@ -99,18 +100,7 @@ public class ZipWriterTest {
     static {
         Log4jInit.setLevel("ca.nrc.cadc.caom2.pkg", Level.INFO);
     }
-    
-    //@Test
-    public void testTemplate() {
-        try {
-            
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("Unexpected exception: " + unexpected);
-        }
-        
-    }
-    
+
     @Test
     public void testCreateZip() {
         try {
@@ -125,7 +115,7 @@ public class ZipWriterTest {
             packageContents.add(pi2);
 
             File tmp = File.createTempFile("ziptest", ".zip");
-            FileOutputStream fos=  new FileOutputStream(tmp);
+            FileOutputStream fos =  new FileOutputStream(tmp);
             ArchiveWriter fw = new ZipWriter(fos);
             for (PackageItem pi : packageContents) {
                 fw.write(pi);
@@ -160,8 +150,7 @@ public class ZipWriterTest {
             get2.prepare();
             Assert.assertArrayEquals(c2.content, getUrlPayload(get2));
 
-        }
-        catch (Exception unexpected) {
+        } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);
             Assert.fail("Unexpected exception: " + unexpected);
         }
@@ -180,7 +169,7 @@ public class ZipWriterTest {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        byte buffer[] = new byte[2048];
+        byte[] buffer = new byte[2048];
         int read = 0;
         while ((read = zip.read(buffer)) > 0) {
             out.write(buffer, 0, read);
@@ -191,11 +180,11 @@ public class ZipWriterTest {
 
     private byte[] getUrlPayload(HttpGet get) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        int nRead;
+        int numRead;
         byte[] data = new byte[16384];
 
-        while ((nRead = get.getInputStream().read(data, 0, data.length)) != -1) {
-            buffer.write(data, 0, nRead);
+        while ((numRead = get.getInputStream().read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, numRead);
         }
         return buffer.toByteArray();
     }


### PR DESCRIPTION
Updates to work adamian did for initial ZipWriter. Added check for RESPONSEFORMAT in the incoming job to separate this out from updating caom2-pkg-server to have a RESPONSEFORMAT parameter. 