### PR TITLE
CADC-10493: remove unused getPackagename() from PackageRunner

### DIFF
--- a/cadc-pkg-server/build.gradle
+++ b/cadc-pkg-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.1.0'
+version = '1.1.1'
 
 description = 'OpenCADC CADC package server library'
 def git_url = 'https://github.com/opencadc/dal'

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/PackageRunner.java
@@ -121,12 +121,6 @@ public abstract class PackageRunner implements JobRunner {
      */
     protected abstract Iterator<PackageItem> getItems() throws IOException;
 
-    /**
-     * Get name for package Runner will create.
-     * @return String with package name.
-     */
-    protected abstract String getPackageName();
-
     @Override
     public void setJob(Job job) {
         this.job = job;


### PR DESCRIPTION
Should have been done as part of last code review response, but was missed. Removing now before next PackageRunner implementation is done in the zip download story. Tested against caom2ops and vault implementations.