### PR TITLE
fix: set default permissions in zip file entries to maintain readability

### DIFF
--- a/cadc-pkg-server/build.gradle
+++ b/cadc-pkg-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '1.2.4'
+version = '1.2.5'
 
 description = 'OpenCADC CADC package server library'
 def git_url = 'https://github.com/opencadc/dal'

--- a/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
+++ b/cadc-pkg-server/src/main/java/org/opencadc/pkg/server/ZipWriter.java
@@ -93,7 +93,7 @@ public class ZipWriter extends PackageWriter {
         log.debug(String.format("file ArchiveEntry: %s %s %s", relativePath, size, lastModifiedDate));
 
         ZipArchiveEntry entry = new ZipArchiveEntry(relativePath);
-        entry.setUnixMode(UnixStat.FILE_FLAG);
+        entry.setUnixMode(UnixStat.FILE_FLAG + UnixStat.DEFAULT_FILE_PERM);
         entry.setSize(size);
         if (lastModifiedDate != null) {
             entry.setLastModifiedTime(FileTime.fromMillis(lastModifiedDate.getTime()));
@@ -113,7 +113,7 @@ public class ZipWriter extends PackageWriter {
         }
 
         ZipArchiveEntry entry =  new ZipArchiveEntry(relativePath);
-        entry.setUnixMode(UnixStat.DIR_FLAG);
+        entry.setUnixMode(UnixStat.DIR_FLAG + UnixStat.DEFAULT_DIR_PERM);
         return entry;
     }
 
@@ -122,7 +122,7 @@ public class ZipWriter extends PackageWriter {
         log.debug(String.format("symbolic link ArchiveEntry: %s -> %s", relativePath, linkRelativePath));
 
         ZipArchiveEntry entry = new ZipArchiveEntry(relativePath);
-        entry.setUnixMode(UnixStat.LINK_FLAG);
+        entry.setUnixMode(UnixStat.LINK_FLAG + UnixStat.DEFAULT_LINK_PERM);
         return entry;
     }
 

--- a/cadc-sia/src/main/java/ca/nrc/cadc/sia2/SiaRunner.java
+++ b/cadc-sia/src/main/java/ca/nrc/cadc/sia2/SiaRunner.java
@@ -128,7 +128,7 @@ public class SiaRunner implements JobRunner {
     }
 
     public void run() {
-        log.debug("RUN SiaRunner: " + job.ownerSubject);
+        log.debug("RUN SiaRunner: " + job.owner);
 
         logInfo = new JobLogInfo(job);
 


### PR DESCRIPTION
# Description
Creating a ZIP file for download, and then extracting it on a local machine results in files and folders with no UNIX permissions set on them.  Adding the default values will allow users to not need to extra step of setting permissions on local files.

# Changes
- Set default permissions
- Add test
  - The Apache `ZipArchiveInputStream` does *not* preserve permissions.  The standard `java.util.zip` package was used to test.